### PR TITLE
chore: refresh links + README after WG modernization

### DIFF
--- a/.github/ISSUE_TEMPLATE/editorial---markup-issue.md
+++ b/.github/ISSUE_TEMPLATE/editorial---markup-issue.md
@@ -3,7 +3,7 @@ name: Editorial / Markup issue
 about: Editorial clarifications, link and markup fixes, ...
 title: "[simple]"
 labels: editorial
-assignees: ccordi, chaals, math0graham
+assignees: ccordi, math0graham
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -3,7 +3,7 @@ name: Feature request
 about: Suggest an idea for this project
 title: "[BUG/FEATURE]"
 labels: Not yet considered
-assignees: chaals
+assignees: ccordi
 
 ---
 
@@ -15,7 +15,7 @@ A clear and concise description of the problem explains how it occurs.
 It is appropriate to provide links to a detailed description, alongside a brief summary.
 Links provided without context will be ignored.
 
-If you describe a preferred solution, please first complete the [non-member participation agreement]([EEA-Non-Member-Participation-Agreement.pdf](https://github.com/EntEthAlliance/EthTrust-public/blob/main/EEA-Non-Member-Participation-Agreement.pdf)) and [notify EEA](https://entethalliance.org/contact/) to submit it. That agreement is broadly to respect confidentiality in any discussions held in confidence, and to ensure malicious actors do not try to introduce patented materials into key specifications, and subsequently try to raise license fees from the industry. 
+If you describe a preferred solution, please first complete the [non-member participation agreement](https://github.com/EntEthAlliance/EthTrust-public/blob/main/EEA-Non-Member-Participation-Agreement.pdf) and [notify EEA](https://entethalliance.org/contact/) to submit it. That agreement is broadly to respect confidentiality in any discussions held in confidence, and to ensure malicious actors do not try to introduce patented materials into key specifications, and subsequently try to raise license fees from the industry. 
 
 **Describe alternatives you've considered**
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,51 @@
-# EthTrust-public
+# EthTrust — Public Comment
 
-This repository is to enable public comment on the [EEA EthTrust Security Levels Specification](https://entethalliance.github.io/eta-registry/security-levels-spec.html)
-and other work of the [EthTrust Security Levels Working Group](https://entethalliance.org/groups/EthTrust).
+**The public comment channel for the
+[EEA EthTrust Security Levels Specification](https://entethalliance.org/specs/ethtrust-sl/v3/)**
+and other work of the
+[EthTrust Security Levels Working Group](https://entethalliance.github.io/wg-ethtrust-site/).
 
-Comments should be made by adding a comment to an [open issue](https://github.com/EntEthAlliance/EthTrust-public/issues) if there is a relevant issue already, or by creating a 
-[new issue](https://github.com/EntEthAlliance/EthTrust-public/issues/new/choose). If proposals are editorial in nature (i.e. they clarify wording, fix spelling mistakes or obvious logic errors),
-the process is fairly straightforward. If a proposal suggests a substantive change - e.g. adding a new requirement, or changing a requirement so it will be tested differently, 
-through the issue template we request the commenter to complete the [EEA Non-member participation agreement](https://github.com/EntEthAlliance/EthTrust-public/blob/main/EEA-Non-Member-Participation-Agreement.pdf). Essentially this is an agreement not to introduce material covered by a "submarine patent",
-and to respect any confidential information provided by the group, although that will usually be minimal or none.
+Anyone may raise feedback here — you do not need to be an EEA member.
 
-The Working Group will consider the issues raised, reply in the public issue as they make progress or request clarification, and explain their resolution and the outcome of each issue.
-The group **MAY** invite individuals who have raised issues to participate in a dicussion. Any member of EEA is automatically entitled to participate in the Working Group.
+---
 
-For information on joining the EEA please visit http://entethalliance.org/become-a-member
+## 📄 The specification
+
+| | |
+|---|---|
+| **Current version** | [EEA EthTrust Security Levels Specification v3](https://entethalliance.org/specs/ethtrust-sl/v3/) (March 2025) |
+| **Checklist of requirements** | [v3 checklist](https://entethalliance.org/specs/ethtrust-sl/v3/checklist.html) |
+| **Previous versions** | [v2](https://entethalliance.org/specs/ethtrust-sl/v2) (Dec 2023) · [v1](https://entethalliance.org/specs/ethtrust-sl/v1/) (Aug 2022) |
+| **Working Group** | [EthTrust Security Levels WG](https://entethalliance.github.io/wg-ethtrust-site/) |
+
+## 💬 How to comment
+
+1. **Check the [open issues](https://github.com/EntEthAlliance/EthTrust-public/issues)** —
+   if a relevant issue already exists, add your comment there.
+2. Otherwise **[open a new issue](https://github.com/EntEthAlliance/EthTrust-public/issues/new/choose)**,
+   picking the template that fits:
+   - **Editorial / markup** — wording clarifications, spelling, broken links,
+     obvious logic errors. Straightforward; no paperwork.
+   - **Substantive change** — anything that adds a requirement or changes how
+     one is tested. The issue template asks you to complete the
+     [EEA Non-Member Participation Agreement](EEA-Non-Member-Participation-Agreement.pdf)
+     and [notify the EEA](https://entethalliance.org/contact/). In essence: an
+     agreement not to introduce material covered by a "submarine patent", and
+     to respect any confidential information provided by the group (usually
+     minimal or none).
+
+Please include a name with your contribution so it can be publicly
+acknowledged.
+
+## 🔁 What happens next
+
+The Working Group considers the issues raised, replies in the public issue as
+it makes progress or needs clarification, and records its resolution and the
+outcome of each issue. The group **MAY** invite individuals who raised issues
+to join a discussion.
+
+## 🤝 Joining the EEA
+
+Any EEA member is automatically entitled to participate in the Working Group.
+For information on joining, visit
+[entethalliance.org/become-a-member](https://entethalliance.org/become-a-member/).


### PR DESCRIPTION
## Intended end state
The public-comment repo works again end to end: un-archived (done repo-side), README points at the canonical v3 spec/checklist and the new WG site, comment flow is clearly explained, and issue templates assign current co-chairs.

## Scope and non-goals
README + two issue templates. Non-goals: no change to the participation-agreement PDF or the comment process itself; issue #7 triage stays with the co-chairs.

## Why this matters
The published v3 spec directs readers to raise feedback here, but the repo was archived — the public-comment channel the spec promises was locked. Redwan directed un-archive + refresh (Telegram 2026-08-24 21:38 UTC), plus admin changes (Redoudou/claudyfaucant admin — already were; chaals removed).

## Documentation impact
README is the documentation and is the thing updated. Repo description + homepage also set (WG site).

## Review / re-baseline status
Fresh docs-only PR.

## Testing and evidence
All README URLs curl-checked 200 (canonical spec URLs, WG site, become-a-member, contact). Template front-matter parses (name/about/labels/assignees preserved).

## Issue
Tracked on wg-ethtrust-site#4 (modernization tracking issue — updating it after merge).

## Limitations or uncertainty
Why the repo was archived remains unknown — un-archiving was Redwan's explicit call. EEASecretariat admin left untouched (not in scope of the instruction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)