### PR TITLE
chore: point v3 spec links at the redesigned copies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # EthTrust — Public Comment
 
 **The public comment channel for the
-[EEA EthTrust Security Levels Specification](https://entethalliance.org/specs/ethtrust-sl/v3/)**
+[EEA EthTrust Security Levels Specification](https://entethalliance.github.io/wg-ethtrust-site/spec/v3/)**
 and other work of the
 [EthTrust Security Levels Working Group](https://entethalliance.github.io/wg-ethtrust-site/).
 
@@ -13,8 +13,8 @@ Anyone may raise feedback here — you do not need to be an EEA member.
 
 | | |
 |---|---|
-| **Current version** | [EEA EthTrust Security Levels Specification v3](https://entethalliance.org/specs/ethtrust-sl/v3/) (March 2025) |
-| **Checklist of requirements** | [v3 checklist](https://entethalliance.org/specs/ethtrust-sl/v3/checklist.html) |
+| **Current version** | [EEA EthTrust Security Levels Specification v3](https://entethalliance.github.io/wg-ethtrust-site/spec/v3/) (March 2025) |
+| **Checklist of requirements** | [v3 checklist](https://entethalliance.github.io/wg-ethtrust-site/spec/v3/checklist.html) |
 | **Previous versions** | [v2](https://entethalliance.org/specs/ethtrust-sl/v2) (Dec 2023) · [v1](https://entethalliance.org/specs/ethtrust-sl/v1/) (Aug 2022) |
 | **Working Group** | [EthTrust Security Levels WG](https://entethalliance.github.io/wg-ethtrust-site/) |
 


### PR DESCRIPTION
## Intended end state
README's v3 spec + checklist links open the new-branding versions (WG site copies) instead of the old-design canonical URLs.

## Scope and non-goals
Two URLs in README.md. v1/v2 stay canonical — no restyled copies exist. Non-goal: this is temporary routing; after the WP Engine swap puts the new design on the canonical URLs, these flip back (tracked in wg-ethtrust-site#4).

## Why this matters
Redwan's review (Telegram 21:50 UTC): links should show the new branding.

## Documentation impact
README is the change.

## Review / re-baseline status
Amend to today's PR #8.

## Testing and evidence
Both target URLs return 200 and carry the editorial design + GA tag (verified earlier tonight).

## Issue
wg-ethtrust-site#4.

## Limitations or uncertainty
Content-identical copies; canonical tags on those pages already point to the official URLs, so SEO is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)