### PR TITLE
feat: solicit public feedback on the v4 review draft

### DIFF
--- a/.github/ISSUE_TEMPLATE/v4-draft-review.md
+++ b/.github/ISSUE_TEMPLATE/v4-draft-review.md
@@ -1,0 +1,25 @@
+---
+name: v4 Draft Review feedback
+about: Feedback on the EthTrust Security Levels v4 review draft (not yet an approved specification)
+title: "[v4-review] "
+labels: v4-review
+assignees: ccordi
+
+---
+
+**What this is for:** the Working Group is collecting expert feedback on the
+[EthTrust v4 review draft](https://entethalliance.github.io/wg-ethtrust-site/spec/v4/) —
+an AI-generated initial draft published for validation. It is **not** an
+approved EEA specification; the approved baseline remains
+[version 3](https://entethalliance.github.io/wg-ethtrust-site/spec/v3/).
+
+**Section of the draft** (URL or heading):
+
+**Your feedback** — anything from "this requirement is wrong/untestable" to
+"this correctly captures current practice":
+
+**If you propose substantive new requirement text**, please first complete the
+[non-member participation agreement](https://github.com/EntEthAlliance/EthTrust-public/blob/main/EEA-Non-Member-Participation-Agreement.pdf)
+and [notify EEA](https://entethalliance.org/contact/) — see the repo README for why.
+
+Please include a name so your contribution can be publicly acknowledged.

--- a/README.md
+++ b/README.md
@@ -9,6 +9,19 @@ Anyone may raise feedback here — you do not need to be an EEA member.
 
 ---
 
+## 🔍 Now in public review: the v4 draft
+
+The Working Group has published an **[EthTrust v4 review draft](https://entethalliance.github.io/wg-ethtrust-site/spec/v4/)**
+— an AI-generated initial draft seeking expert validation. It is **not an
+approved EEA specification**; [version 3](https://entethalliance.github.io/wg-ethtrust-site/spec/v3/)
+remains the current approved baseline and certification target.
+
+**We want your feedback** — on candidate requirements, testability, the
+v3 → v4 changes, and anything the draft gets wrong or misses:
+**[open a v4 Draft Review issue](https://github.com/EntEthAlliance/EthTrust-public/issues/new?template=v4-draft-review.md)**.
+
+---
+
 ## 📄 The specification
 
 | | |
@@ -16,6 +29,7 @@ Anyone may raise feedback here — you do not need to be an EEA member.
 | **Current version** | [EEA EthTrust Security Levels Specification v3](https://entethalliance.github.io/wg-ethtrust-site/spec/v3/) (March 2025) |
 | **Checklist of requirements** | [v3 checklist](https://entethalliance.github.io/wg-ethtrust-site/spec/v3/checklist.html) |
 | **Previous versions** | [v2](https://entethalliance.github.io/wg-ethtrust-site/spec/v2/) (Dec 2023) · [v1](https://entethalliance.github.io/wg-ethtrust-site/spec/v1/) (Aug 2022) |
+| **Review draft** | [v4 draft](https://entethalliance.github.io/wg-ethtrust-site/spec/v4/) — in public review, not approved |
 | **Working Group** | [EthTrust Security Levels WG](https://entethalliance.github.io/wg-ethtrust-site/) |
 
 ## 💬 How to comment


### PR DESCRIPTION
## Intended end state
Visitors to the public-comment repo are actively invited to review the v4 draft: README callout + table row, and a dedicated issue template (label `v4-review`, assigned to ccordi) that frames the draft correctly — AI-generated, for expert validation, not an approved spec, v3 remains the baseline.

## Scope and non-goals
README + one new issue template + one label. Non-goals: no change to the v4 page itself (Redwan's); v3 comment flow untouched.

## Why this matters
Redwan's request (Telegram 23:20 UTC): point this repo's feedback machinery at the v4 draft now in public review.

## Documentation impact
README is the change; template self-documents.

## Review / re-baseline status
Builds on tonight's refresh PRs (#8–#10).

## Testing and evidence
Template front-matter validated; draft URL returns 200; framing language mirrors the WG page's own labelling.

## Issue
A pinned review issue follows the merge; tracked on wg-ethtrust-site#4.

## Limitations or uncertainty
Assignee is ccordi (current co-chair); switch to Redoudou if Redwan wants v4 triage himself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)